### PR TITLE
Restore CLion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,5 @@ I'm aware of these other plugins, which are for different assemblers.
 - [4ch1m/kick-assembler-acbg](https://github.com/4ch1m/kick-assembler-acbg) - Kick Assembler
 - [67726e/IntelliJ-6502](https://github.com/67726e/IntelliJ-6502) - NESASM
 - [matozoid/Intellij6502](https://github.com/matozoid/Intellij6502) - 64tass
+- [chrisly42/mc68000-asm-plugin](https://git.platon42.de/chrisly42/mc68000-asm-plugin) - targets Motorola 68000 (VASM)
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 group 'org.ca65'
-version '1.8'
+version '1.9'
 
 repositories {
     mavenCentral()
@@ -53,7 +53,7 @@ intellijPlatform {
             // against newer IDE builds.
             untilBuild = provider { null }
         }
-        changeNotes = """This is a maintenance release which updates the plugin's dependencies. The minimum IDE version is now 2024.2."""
+        changeNotes = """This release adds CLion support. The plugin's file type was renamed to avoid a name clash with CLion's bundled assembly support."""
     }
 
     pluginVerification {
@@ -63,6 +63,8 @@ intellijPlatform {
         ides {
             ide IntelliJPlatformType.IntellijIdeaCommunity, '2024.2'
             ide IntelliJPlatformType.IntellijIdeaCommunity, '2024.3'
+            // CLion is now a supported target
+            ide IntelliJPlatformType.CLion, '2024.2'
         }
     }
 

--- a/src/main/java/org/ca65/AsmFileType.java
+++ b/src/main/java/org/ca65/AsmFileType.java
@@ -15,7 +15,7 @@ public class AsmFileType extends LanguageFileType {
     @NotNull
     @Override
     public String getName() {
-        return "Assembly file";
+        return "6502 Assembly";
     }
 
     @Override

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -13,11 +13,9 @@
   <!-- please see https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html
        on how to target different products -->
   <depends>com.intellij.modules.platform</depends>
-  
-  <incompatible-with>com.intellij.modules.clion</incompatible-with>
 
   <extensions defaultExtensionNs="com.intellij">
-    <fileType name="Assembly file" implementationClass="org.ca65.AsmFileType" fieldName="INSTANCE"
+    <fileType name="6502 Assembly" implementationClass="org.ca65.AsmFileType" fieldName="INSTANCE"
               language="6502 Assembly" extensions="s;asm;inc;mac"/>
     <lang.parserDefinition language="6502 Assembly"
                            implementationClass="org.ca65.AsmParserDefinition"/>


### PR DESCRIPTION
The the name "Assembly File" clashed with the built-in support in CLion, and it works after a rename.

<img width="1970" height="1216" alt="it-works" src="https://github.com/user-attachments/assets/4292990e-e74f-4ce6-9878-95f0a92e8293" />

Figured this out by comparing this plugin's `plugin.xml` to [chrisly42/mc68000-asm-plugin](https://git.platon42.de/chrisly42/mc68000-asm-plugin), which didn't have the same compatibility issue.