### PR TITLE
Add numeric consts to structure view - they were previously left out

### DIFF
--- a/src/main/java/org/ca65/AsmIcons.java
+++ b/src/main/java/org/ca65/AsmIcons.java
@@ -7,6 +7,7 @@ import javax.swing.*;
 public class AsmIcons {
     public static final Icon ASSEMBLY_FILE = IconLoader.getIcon("/icons/assembly.svg", AsmIcons.class);
     public static final Icon LABEL = IconLoader.getIcon("/icons/label.svg", AsmIcons.class);
+    public static final Icon NUMERIC_CONST = IconLoader.getIcon("/icons/numericConst.svg", AsmIcons.class);
 
     public static final Icon JUMP_TO_LABEL = IconLoader.getIcon("/icons/jumpToLabel.svg", AsmIcons.class);
     public static final Icon JUMP_TO_LOCAL_LABEL = IconLoader.getIcon("/icons/jumpToLocalLabel.svg", AsmIcons.class);

--- a/src/main/java/org/ca65/AsmStructureViewElement.java
+++ b/src/main/java/org/ca65/AsmStructureViewElement.java
@@ -7,8 +7,10 @@ import com.intellij.ide.util.treeView.smartTree.TreeElement;
 import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.NavigatablePsiElement;
 import com.intellij.psi.util.PsiTreeUtil;
+import org.ca65.psi.AsmDefineConstantNumeric;
 import org.ca65.psi.AsmFile;
 import org.ca65.psi.AsmMarker;
+import org.ca65.psi.impl.AsmDefineConstantNumericImpl;
 import org.ca65.psi.impl.AsmMarkerImpl;
 import org.ca65.psi.impl.AsmPsiImplUtil;
 import org.jetbrains.annotations.NotNull;
@@ -39,6 +41,8 @@ public class AsmStructureViewElement implements StructureViewTreeElement, Sortab
         if (this.element instanceof AsmMarker) {
             // Not sure why this.element.getPresentation() is always null for this?
             return AsmPsiImplUtil.getPresentation((AsmMarker)this.element);
+        } else if (this.element instanceof AsmDefineConstantNumeric) {
+            return AsmPsiImplUtil.getPresentation((AsmDefineConstantNumeric)this.element);
         }
         ItemPresentation presentation = this.element.getPresentation();
         return presentation != null ? presentation : new PresentationData();
@@ -47,16 +51,17 @@ public class AsmStructureViewElement implements StructureViewTreeElement, Sortab
     @Override
     public TreeElement @NotNull [] getChildren() {
         if (this.element instanceof AsmFile) {
-            List<AsmMarker> markers = PsiTreeUtil.getChildrenOfTypeAsList(this.element, AsmMarker.class);
-            List<TreeElement> treeElements = new ArrayList<>(markers.size());
-            for (AsmMarker marker : markers) {
+            List<TreeElement> treeElements = new ArrayList<>();
+            for (AsmMarker marker : PsiTreeUtil.getChildrenOfTypeAsList(this.element, AsmMarker.class)) {
                 AsmMarkerImpl markerImpl = (AsmMarkerImpl) marker;
-                if(markerImpl.getText().startsWith(":")) {
+                if (markerImpl.getText().startsWith(":")) {
                     // exclude blank labels
                     continue;
                 }
                 treeElements.add(new AsmStructureViewElement(markerImpl));
-
+            }
+            for (AsmDefineConstantNumeric constant : PsiTreeUtil.getChildrenOfTypeAsList(this.element, AsmDefineConstantNumeric.class)) {
+                treeElements.add(new AsmStructureViewElement((AsmDefineConstantNumericImpl) constant));
             }
             return treeElements.toArray(new TreeElement[0]);
         }

--- a/src/main/java/org/ca65/psi/impl/AsmPsiImplUtil.java
+++ b/src/main/java/org/ca65/psi/impl/AsmPsiImplUtil.java
@@ -6,6 +6,7 @@ import com.intellij.navigation.ItemPresentation;
 import com.intellij.psi.PsiElement;
 import org.ca65.AsmIcons;
 import org.ca65.psi.*;
+import org.ca65.psi.AsmDefineConstantNumeric;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
@@ -100,6 +101,28 @@ public class AsmPsiImplUtil {
             @Override
             public Icon getIcon(boolean unused) {
                 return element.getText().startsWith("@") || element.getText().startsWith(":") ? AllIcons.Nodes.Annotationtype : AsmIcons.LABEL;
+            }
+        };
+    }
+
+    public static ItemPresentation getPresentation(AsmDefineConstantNumeric element) {
+        return new ItemPresentation() {
+            @Nullable
+            @Override
+            public String getPresentableText() {
+                return element.getIdentifierdef().getName();
+            }
+
+            @Nullable
+            @Override
+            public String getLocationString() {
+                return element.getContainingFile().getName();
+            }
+
+            @Nullable
+            @Override
+            public Icon getIcon(boolean unused) {
+                return AsmIcons.NUMERIC_CONST;
             }
         };
     }


### PR DESCRIPTION
This adds numeric consts to the structure view using the new icons - these were previously left out:

<img width="2110" height="1172" alt="image" src="https://github.com/user-attachments/assets/4afe9fc0-d77a-4826-8c21-3790a0264480" />
