### PR TITLE
Re-visit numeric literal conversion

### DIFF
--- a/src/main/java/org/ca65/AsmDocumentationProvider.java
+++ b/src/main/java/org/ca65/AsmDocumentationProvider.java
@@ -1,0 +1,72 @@
+package org.ca65;
+
+import com.intellij.lang.documentation.AbstractDocumentationProvider;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.util.PsiTreeUtil;
+import org.ca65.psi.AsmNumericLiteral;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class AsmDocumentationProvider extends AbstractDocumentationProvider {
+
+    @Override
+    public @Nullable PsiElement getCustomDocumentationElement(@NotNull Editor editor,
+                                                              @NotNull PsiFile file,
+                                                              @Nullable PsiElement contextElement,
+                                                              int targetOffset) {
+        if (contextElement == null) return null;
+        return PsiTreeUtil.getParentOfType(contextElement, AsmNumericLiteral.class, false);
+    }
+
+    @Override
+    public @Nullable String generateDoc(PsiElement element, @Nullable PsiElement originalElement) {
+        if (!(element instanceof AsmNumericLiteral)) return null;
+        String text = element.getText();
+        int value;
+        try {
+            value = parseNumericLiteral(text);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+        StringBuilder sb = new StringBuilder("<table>");
+        appendRow(sb, "Hexadecimal", toHex(value), text.startsWith("$"));
+        appendRow(sb, "Decimal", Integer.toString(value), !text.startsWith("$") && !text.startsWith("%"));
+        appendRow(sb, "Binary", toBinary(value), text.startsWith("%"));
+        sb.append("</table>");
+        return sb.toString();
+    }
+
+    private static int parseNumericLiteral(String text) {
+        String digits = text.replace("_", "");
+        if (digits.startsWith("$")) {
+            return Integer.parseInt(digits.substring(1), 16);
+        } else if (digits.startsWith("%")) {
+            return Integer.parseInt(digits.substring(1), 2);
+        } else {
+            return Integer.parseInt(digits, 10);
+        }
+    }
+
+    private static String toHex(int value) {
+        String raw = Integer.toHexString(value);
+        if (raw.length() % 2 == 1) raw = "0" + raw;
+        return "$" + raw;
+    }
+
+    private static String toBinary(int value) {
+        String raw = Integer.toBinaryString(value);
+        int remainder = raw.length() % 8;
+        if (remainder != 0) raw = "0".repeat(8 - remainder) + raw;
+        return "%" + raw;
+    }
+
+    private static void appendRow(StringBuilder sb, String label, String value, boolean isCurrent) {
+        sb.append("<tr><td><b>").append(label).append(":</b>&nbsp;</td><td>");
+        if (isCurrent) sb.append("<b>");
+        sb.append(value);
+        if (isCurrent) sb.append("</b>");
+        sb.append("</td></tr>");
+    }
+}

--- a/src/main/java/org/ca65/psi/AsmElementFactory.java
+++ b/src/main/java/org/ca65/psi/AsmElementFactory.java
@@ -1,7 +1,6 @@
 package org.ca65.psi;
 
 import com.intellij.openapi.project.Project;
-import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFileFactory;
 import org.ca65.AsmFileType;
 import org.ca65.psi.impl.AsmLocalLabelRef;
@@ -39,9 +38,9 @@ public class AsmElementFactory {
         return (AsmIdentifierdef) file.getFirstChild().getFirstChild().getNextSibling().getNextSibling();
     }
 
-    public static PsiElement createNumericLiteral(Project project, String newLiteral) {
-        String text = "lda " + newLiteral;
+    public static AsmNumericLiteral createNumericLiteral(Project project, String newLiteral) {
+        String text = "lda " + newLiteral + "\n";
         final AsmFile file = createFile(project, text);
-        return file.getFirstChild().getNextSibling().getNextSibling();
+        return (AsmNumericLiteral) file.getFirstChild().getFirstChild().getNextSibling().getNextSibling().getFirstChild().getFirstChild();
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -42,6 +42,7 @@
     <annotator language="6502 Assembly" implementationClass="org.ca65.annotator.AsmUnusedReferenceAnnotator"/>
     <annotator language="6502 Assembly" implementationClass="org.ca65.annotator.AsmNumericLiteralAnnotator"/>
     <projectService serviceImplementation="org.ca65.config.AsmConfiguration" />
+    <lang.documentationProvider language="6502 Assembly" implementationClass="org.ca65.AsmDocumentationProvider"/>
 
     <intentionAction>
       <className>org.ca65.action.ConvertNumberToHexadecimalIntentionAction</className>


### PR DESCRIPTION
Converting between binary/decimal/hex using quick-fix turned out to be a bit buggy when used frequently. The PSI element replacement was a bit unreliable.

<img width="1133" height="218" alt="image" src="https://github.com/user-attachments/assets/ba9dd732-9757-4452-bdd4-0084f1c66d67" />

I also implemented some user feedback which requested a tooltip display of alternative number formats.

<img width="852" height="376" alt="image" src="https://github.com/user-attachments/assets/835efe3c-1e95-457d-b68c-776528cb5d6a" />

I'll likely need a documentation provider to provide built-in help for mnemonics, so this is an easy way to test it out.
