### PR TITLE
Changes to origin statement handling

### DIFF
--- a/src/main/java/org/ca65/Asm.bnf
+++ b/src/main/java/org/ca65/Asm.bnf
@@ -18,7 +18,7 @@ implements("identifierdef")="com.intellij.psi.PsiNamedElement"
 
 asmFile ::= item_*
 
-private item_ ::= marker? (dotexpr|register_dotexpr|imports|define_constant_label|define_constant_numeric|macro|llabel)? COMMENT? EOL_WS
+private item_ ::= marker? (dotexpr|register_dotexpr|imports|define_constant_label|define_constant_numeric|macro|llabel|star_assign)? COMMENT? EOL_WS
 
 marker ::= (LABEL | SHORTLABEL) {
     mixin="org.ca65.psi.impl.AsmLabelDefinitionImpl"
@@ -37,6 +37,7 @@ llabel ::=  instruction_mnemonic expr?
 
 define_constant_numeric ::= identifierdef ( EQUALS ) expr
 define_constant_label ::= identifierdef ( COLON_EQUALS ) expr
+star_assign ::= MUL EQUALS expr
 
 expr ::= anything*
 

--- a/src/main/java/org/ca65/action/ConvertStarAssignToOrgIntentionAction.java
+++ b/src/main/java/org/ca65/action/ConvertStarAssignToOrgIntentionAction.java
@@ -1,0 +1,48 @@
+package org.ca65.action;
+
+import com.intellij.codeInsight.intention.IntentionAction;
+import com.intellij.codeInspection.util.IntentionFamilyName;
+import com.intellij.codeInspection.util.IntentionName;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiFile;
+import com.intellij.util.IncorrectOperationException;
+import org.ca65.Asm6502Bundle;
+import org.ca65.psi.AsmStarAssign;
+import org.jetbrains.annotations.NotNull;
+
+public class ConvertStarAssignToOrgIntentionAction implements IntentionAction {
+    private final AsmStarAssign element;
+
+    public ConvertStarAssignToOrgIntentionAction(@NotNull AsmStarAssign element) {
+        this.element = element;
+    }
+
+    @Override
+    public @IntentionName @NotNull String getText() {
+        return Asm6502Bundle.message("INTN.convert.star.assign.to.org", element.getExpr().getText());
+    }
+
+    @Override
+    public @NotNull @IntentionFamilyName String getFamilyName() {
+        return Asm6502Bundle.message("INTN.NAME.convert.star.assign.to.org");
+    }
+
+    @Override
+    public boolean isAvailable(@NotNull Project project, Editor editor, PsiFile file) {
+        return element.isValid();
+    }
+
+    @Override
+    public void invoke(@NotNull Project project, Editor editor, PsiFile file) throws IncorrectOperationException {
+        TextRange range = element.getTextRange();
+        editor.getDocument().replaceString(range.getStartOffset(), range.getEndOffset(),
+                ".org " + element.getExpr().getText());
+    }
+
+    @Override
+    public boolean startInWriteAction() {
+        return true;
+    }
+}

--- a/src/main/java/org/ca65/annotator/AsmStarAssignAnnotator.java
+++ b/src/main/java/org/ca65/annotator/AsmStarAssignAnnotator.java
@@ -1,0 +1,21 @@
+package org.ca65.annotator;
+
+import com.intellij.lang.annotation.AnnotationHolder;
+import com.intellij.lang.annotation.Annotator;
+import com.intellij.lang.annotation.HighlightSeverity;
+import com.intellij.psi.PsiElement;
+import org.ca65.Asm6502Bundle;
+import org.ca65.action.ConvertStarAssignToOrgIntentionAction;
+import org.ca65.psi.AsmStarAssign;
+import org.jetbrains.annotations.NotNull;
+
+public class AsmStarAssignAnnotator implements Annotator {
+    @Override
+    public void annotate(@NotNull PsiElement element, @NotNull AnnotationHolder holder) {
+        if (!(element instanceof AsmStarAssign)) return;
+        holder.newAnnotation(HighlightSeverity.WARNING, Asm6502Bundle.message("INSPECT.star.assign"))
+                .range(element.getTextRange())
+                .withFix(new ConvertStarAssignToOrgIntentionAction((AsmStarAssign) element))
+                .create();
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -41,6 +41,7 @@
     <annotator language="6502 Assembly" implementationClass="org.ca65.annotator.AsmUnresolvedReferenceAnnotator"/>
     <annotator language="6502 Assembly" implementationClass="org.ca65.annotator.AsmUnusedReferenceAnnotator"/>
     <annotator language="6502 Assembly" implementationClass="org.ca65.annotator.AsmNumericLiteralAnnotator"/>
+    <annotator language="6502 Assembly" implementationClass="org.ca65.annotator.AsmStarAssignAnnotator"/>
     <projectService serviceImplementation="org.ca65.config.AsmConfiguration" />
     <lang.documentationProvider language="6502 Assembly" implementationClass="org.ca65.AsmDocumentationProvider"/>
 

--- a/src/main/resources/messages/Asm6502Bundle.properties
+++ b/src/main/resources/messages/Asm6502Bundle.properties
@@ -16,6 +16,9 @@ INSPECT.unresolved.reference=The symbol ''{0}'' is not defined in this file.
 INSPECT.unused.reference=The symbol ''{0}'' is not used in this file.
 INTN.NAME.disable.reference.checking=Disable 6502 assembly reference checking for this project
 
+INSPECT.star.assign=Origin assignment ''* = ...'' is not supported by ca65; use ''.org <address>'' to place absolute code instead.
+INTN.NAME.convert.star.assign.to.org=Replace with .org
+INTN.convert.star.assign.to.org=Replace ''* = {0}'' with ''.org {0}''
 INSPECT.binary.literal.length=Size of binary number ''{0}'' is not a multiple of 8 bits
 INSPECT.hex.literal.length=Size of hex number ''{0}'' is not a multiple of 8 bits
 


### PR DESCRIPTION
This change adds tolerance for `* = $2000` syntax (for setting the origin) at the parse stage. This is not valid ca65 syntax but is used by other classic assemblers.

Currently if you add this to a file, it breaks parsing, so you lose all code assistance. The plugin had some user feedback on the JetBrains marketplace which quoted this error, which is certainly unclear.

<img width="1408" height="325" alt="Screenshot From 2026-06-28 23-38-08" src="https://github.com/user-attachments/assets/94b1730d-1d12-4e96-8ef0-70016c2d0e7d" />

This change is intended to help users who are porting code from another assembler. If you try to use such an assignment, you will get a warning (inspection), plus a quick fix to use the ".org" control command, which is unusual (but possible) in ca65 projects.

<img width="1076" height="326" alt="Screenshot From 2026-06-29 00-11-21" src="https://github.com/user-attachments/assets/e34b9202-9276-4a6d-b8be-4eb6e2cd0d3e" />

And the result of the fix:

<img width="1076" height="326" alt="Screenshot From 2026-06-29 00-11-33" src="https://github.com/user-attachments/assets/12499df8-fc08-4444-a3fd-db936eccdc3a" />

Improving error recovery in the parser is a possible alternative approach.