### PR TITLE
Draft support for ld65 linker configs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,21 @@ tasks.register('generateAsmLexer', GenerateLexerTask) {
     purgeOldFiles = true
 }
 
+tasks.register('generateLd65Parser', GenerateParserTask) {
+    sourceFile = file('src/main/java/org/ca65/ld65/Ld65.bnf')
+    targetRootOutputDir = file('src/main/gen')
+    pathToParser = 'org/ca65/ld65/Ld65Parser.java'
+    pathToPsiRoot = 'org/ca65/ld65/psi'
+    purgeOldFiles = true
+}
+
+tasks.register('generateLd65Lexer', GenerateLexerTask) {
+    sourceFile = file('src/main/java/org/ca65/ld65/Ld65.flex')
+    targetOutputDir = file('src/main/gen/org/ca65/ld65')
+    purgeOldFiles = true
+}
+
 // Make sure generated sources exist before the Java compiler runs.
 tasks.named('compileJava') {
-    dependsOn 'generateAsmLexer', 'generateAsmParser'
+    dependsOn 'generateAsmLexer', 'generateAsmParser', 'generateLd65Lexer', 'generateLd65Parser'
 }

--- a/build.sh
+++ b/build.sh
@@ -3,5 +3,5 @@ set -exu -o pipefail
 rm -Rf build src/main/gen src/main/resources/projectTemplates/*.zip
 # buildPlugin runs the structure/configuration checks; verifyPlugin (2.x plugin)
 # replaces the old runPluginVerifier task and runs the IntelliJ Plugin Verifier.
-./gradlew generateAsmLexer generateAsmParser buildPlugin
+./gradlew generateAsmLexer generateAsmParser generateLd65Lexer generateLd65Parser buildPlugin
 ./gradlew verifyPlugin

--- a/src/main/java/org/ca65/AsmIcons.java
+++ b/src/main/java/org/ca65/AsmIcons.java
@@ -8,6 +8,7 @@ public class AsmIcons {
     public static final Icon ASSEMBLY_FILE = IconLoader.getIcon("/icons/assembly.svg", AsmIcons.class);
     public static final Icon LABEL = IconLoader.getIcon("/icons/label.svg", AsmIcons.class);
     public static final Icon NUMERIC_CONST = IconLoader.getIcon("/icons/numericConst.svg", AsmIcons.class);
+    public static final Icon LINKER = IconLoader.getIcon("/icons/linker.svg", AsmIcons.class);
 
     public static final Icon JUMP_TO_LABEL = IconLoader.getIcon("/icons/jumpToLabel.svg", AsmIcons.class);
     public static final Icon JUMP_TO_LOCAL_LABEL = IconLoader.getIcon("/icons/jumpToLocalLabel.svg", AsmIcons.class);

--- a/src/main/java/org/ca65/ld65/Ld65.bnf
+++ b/src/main/java/org/ca65/ld65/Ld65.bnf
@@ -34,7 +34,7 @@ entry ::= entryName COLON attrList SEMICOLON
 // Entry names may be bare identifiers, quoted strings (%O), or format specifiers (%O/%S)
 private entryName ::= IDENTIFIER | STRING_LITERAL | FORMAT_SPEC
 
-private attrList ::= (attribute (COMMA attribute)*)?
+private attrList ::= (attribute (COMMA? attribute)*)?
 
 // Key = value attribute pair
 attribute ::= IDENTIFIER EQUALS attrValue

--- a/src/main/java/org/ca65/ld65/Ld65.bnf
+++ b/src/main/java/org/ca65/ld65/Ld65.bnf
@@ -1,0 +1,54 @@
+{
+parserClass="org.ca65.ld65.Ld65Parser"
+
+extends="com.intellij.extapi.psi.ASTWrapperPsiElement"
+
+psiClassPrefix="Ld65"
+psiImplClassSuffix="Impl"
+psiPackage="org.ca65.ld65.psi"
+psiImplPackage="org.ca65.ld65.psi.impl"
+
+elementTypeHolderClass="org.ca65.ld65.psi.Ld65Types"
+elementTypeClass="org.ca65.ld65.psi.Ld65ElementType"
+tokenTypeClass="org.ca65.ld65.psi.Ld65TokenType"
+
+// Declare tokens that are used by the lexer but never appear in grammar rules,
+// so GrammarKit still generates their constants in Ld65Types.
+// WHITE_SPACE is intentionally omitted: it comes from com.intellij.psi.TokenType
+// via the flex static import, and adding it here would cause an import ambiguity.
+tokens = [
+    COMMENT = 'COMMENT'
+]
+}
+
+cfgFile ::= section*
+
+// A top-level section block, e.g. MEMORY { ... }
+section ::= sectionKeyword LBRACE entry* RBRACE
+
+private sectionKeyword ::= MEMORY_KW | SEGMENTS_KW | FILES_KW | FORMATS_KW | FEATURES_KW | SYMBOLS_KW
+
+// A named entry inside a section, e.g.  ZP: start = $0000, size = $0100;
+entry ::= entryName COLON attrList SEMICOLON
+
+// Entry names may be bare identifiers, quoted strings (%O), or format specifiers (%O/%S)
+private entryName ::= IDENTIFIER | STRING_LITERAL | FORMAT_SPEC
+
+private attrList ::= (attribute (COMMA attribute)*)?
+
+// Key = value attribute pair
+attribute ::= IDENTIFIER EQUALS attrValue
+
+// Attribute values: either a quoted string (file names) or an arithmetic expression
+attrValue ::= STRING_LITERAL | expr
+
+// Expression with standard arithmetic precedence
+expr ::= exprAdd
+
+private exprAdd  ::= exprMul ((PLUS | MINUS) exprMul)*
+private exprMul  ::= exprUnary ((STAR | DIV) exprUnary)*
+private exprUnary ::= (MINUS | PLUS) exprUnary | exprPrimary
+private exprPrimary ::= IDENTIFIER (COLON IDENTIFIER)?
+                      | INT_LITERAL
+                      | FORMAT_SPEC
+                      | LPAREN exprAdd RPAREN

--- a/src/main/java/org/ca65/ld65/Ld65.flex
+++ b/src/main/java/org/ca65/ld65/Ld65.flex
@@ -1,0 +1,60 @@
+package org.ca65.ld65;
+
+import com.intellij.lexer.FlexLexer;
+import com.intellij.psi.tree.IElementType;
+import static com.intellij.psi.TokenType.*;
+import static org.ca65.ld65.psi.Ld65Types.*;
+
+%%
+%ignorecase
+%class Ld65Lexer
+%implements FlexLexer
+%unicode
+%function advance
+%type IElementType
+%eof{  return;
+%eof}
+
+WHITE_SPACE    = [\ \t\r\n]+
+COMMENT        = "#" [^\r\n]*
+STRING_LITERAL = \" ([^\\\"] | \\[^])* \"
+HEX_LITERAL    = "$" [0-9A-Fa-f]+
+DEC_LITERAL    = [0-9]+
+FORMAT_SPEC    = "%" [OS]
+IDENTIFIER     = [A-Za-z_][A-Za-z0-9_]*
+
+%%
+
+<YYINITIAL> {
+    {WHITE_SPACE}       { return WHITE_SPACE; }
+    {COMMENT}           { return COMMENT; }
+    {STRING_LITERAL}    { return STRING_LITERAL; }
+    {HEX_LITERAL}       { return INT_LITERAL; }
+    {DEC_LITERAL}       { return INT_LITERAL; }
+    {FORMAT_SPEC}       { return FORMAT_SPEC; }
+
+    // Section keywords (must precede IDENTIFIER to take priority on exact match)
+    "MEMORY"            { return MEMORY_KW; }
+    "SEGMENTS"          { return SEGMENTS_KW; }
+    "FILES"             { return FILES_KW; }
+    "FORMATS"           { return FORMATS_KW; }
+    "FEATURES"          { return FEATURES_KW; }
+    "SYMBOLS"           { return SYMBOLS_KW; }
+
+    {IDENTIFIER}        { return IDENTIFIER; }
+
+    "{"                 { return LBRACE; }
+    "}"                 { return RBRACE; }
+    "("                 { return LPAREN; }
+    ")"                 { return RPAREN; }
+    ";"                 { return SEMICOLON; }
+    ","                 { return COMMA; }
+    "="                 { return EQUALS; }
+    ":"                 { return COLON; }
+    "+"                 { return PLUS; }
+    "-"                 { return MINUS; }
+    "*"                 { return STAR; }
+    "/"                 { return DIV; }
+}
+
+[^] { return BAD_CHARACTER; }

--- a/src/main/java/org/ca65/ld65/Ld65FileType.java
+++ b/src/main/java/org/ca65/ld65/Ld65FileType.java
@@ -1,0 +1,35 @@
+package org.ca65.ld65;
+
+import com.intellij.openapi.fileTypes.LanguageFileType;
+import org.ca65.AsmIcons;
+import org.jetbrains.annotations.NotNull;
+
+import javax.swing.*;
+
+public class Ld65FileType extends LanguageFileType {
+    public static final Ld65FileType INSTANCE = new Ld65FileType();
+
+    protected Ld65FileType() {
+        super(Ld65Language.INSTANCE);
+    }
+
+    @Override
+    public @NotNull String getName() {
+        return "ld65 Config";
+    }
+
+    @Override
+    public @NotNull String getDescription() {
+        return "ld65 linker configuration file";
+    }
+
+    @Override
+    public @NotNull String getDefaultExtension() {
+        return "cfg";
+    }
+
+    @Override
+    public Icon getIcon() {
+        return AsmIcons.LINKER;
+    }
+}

--- a/src/main/java/org/ca65/ld65/Ld65Language.java
+++ b/src/main/java/org/ca65/ld65/Ld65Language.java
@@ -1,0 +1,11 @@
+package org.ca65.ld65;
+
+import com.intellij.lang.Language;
+
+public class Ld65Language extends Language {
+    public static final Ld65Language INSTANCE = new Ld65Language();
+
+    protected Ld65Language() {
+        super("ld65 Config");
+    }
+}

--- a/src/main/java/org/ca65/ld65/Ld65LexerAdapter.java
+++ b/src/main/java/org/ca65/ld65/Ld65LexerAdapter.java
@@ -1,0 +1,9 @@
+package org.ca65.ld65;
+
+import com.intellij.lexer.FlexAdapter;
+
+public class Ld65LexerAdapter extends FlexAdapter {
+    public Ld65LexerAdapter() {
+        super(new Ld65Lexer(null));
+    }
+}

--- a/src/main/java/org/ca65/ld65/Ld65ParserDefinition.java
+++ b/src/main/java/org/ca65/ld65/Ld65ParserDefinition.java
@@ -1,0 +1,69 @@
+package org.ca65.ld65;
+
+import com.intellij.lang.ASTNode;
+import com.intellij.lang.ParserDefinition;
+import com.intellij.lang.PsiParser;
+import com.intellij.lexer.Lexer;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.FileViewProvider;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.TokenType;
+import com.intellij.psi.tree.IFileElementType;
+import com.intellij.psi.tree.TokenSet;
+import org.ca65.ld65.psi.Ld65File;
+import org.ca65.ld65.psi.Ld65Types;
+import org.jetbrains.annotations.NotNull;
+
+public class Ld65ParserDefinition implements ParserDefinition {
+    public static final IFileElementType FILE = new IFileElementType(Ld65Language.INSTANCE);
+
+    public static final TokenSet WHITE_SPACES = TokenSet.create(TokenType.WHITE_SPACE);
+    public static final TokenSet COMMENTS = TokenSet.create(Ld65Types.COMMENT);
+    public static final TokenSet STRINGS = TokenSet.create(Ld65Types.STRING_LITERAL);
+
+    @Override
+    public @NotNull Lexer createLexer(Project project) {
+        return new Ld65LexerAdapter();
+    }
+
+    @Override
+    public @NotNull TokenSet getWhitespaceTokens() {
+        return WHITE_SPACES;
+    }
+
+    @Override
+    public @NotNull TokenSet getCommentTokens() {
+        return COMMENTS;
+    }
+
+    @Override
+    public @NotNull TokenSet getStringLiteralElements() {
+        return STRINGS;
+    }
+
+    @Override
+    public @NotNull PsiParser createParser(Project project) {
+        return new Ld65Parser();
+    }
+
+    @Override
+    public @NotNull IFileElementType getFileNodeType() {
+        return FILE;
+    }
+
+    @Override
+    public @NotNull PsiFile createFile(@NotNull FileViewProvider viewProvider) {
+        return new Ld65File(viewProvider);
+    }
+
+    @Override
+    public @NotNull SpaceRequirements spaceExistenceTypeBetweenTokens(ASTNode left, ASTNode right) {
+        return SpaceRequirements.MAY;
+    }
+
+    @Override
+    public @NotNull PsiElement createElement(ASTNode node) {
+        return Ld65Types.Factory.createElement(node);
+    }
+}

--- a/src/main/java/org/ca65/ld65/Ld65SyntaxHighlighter.java
+++ b/src/main/java/org/ca65/ld65/Ld65SyntaxHighlighter.java
@@ -1,0 +1,55 @@
+package org.ca65.ld65;
+
+import com.intellij.lexer.Lexer;
+import com.intellij.openapi.editor.DefaultLanguageHighlighterColors;
+import com.intellij.openapi.editor.colors.TextAttributesKey;
+import com.intellij.openapi.fileTypes.SyntaxHighlighterBase;
+import com.intellij.psi.tree.IElementType;
+import org.ca65.ld65.psi.Ld65Types;
+import org.jetbrains.annotations.NotNull;
+
+import static com.intellij.openapi.editor.colors.TextAttributesKey.createTextAttributesKey;
+
+public class Ld65SyntaxHighlighter extends SyntaxHighlighterBase {
+    public static final TextAttributesKey COMMENT =
+            createTextAttributesKey("LD65_COMMENT", DefaultLanguageHighlighterColors.LINE_COMMENT);
+    public static final TextAttributesKey KEYWORD =
+            createTextAttributesKey("LD65_KEYWORD", DefaultLanguageHighlighterColors.KEYWORD);
+    public static final TextAttributesKey NUMBER =
+            createTextAttributesKey("LD65_NUMBER", DefaultLanguageHighlighterColors.NUMBER);
+    public static final TextAttributesKey STRING =
+            createTextAttributesKey("LD65_STRING", DefaultLanguageHighlighterColors.STRING);
+    public static final TextAttributesKey FORMAT_SPEC =
+            createTextAttributesKey("LD65_FORMAT_SPEC", DefaultLanguageHighlighterColors.KEYWORD);
+    public static final TextAttributesKey IDENTIFIER =
+            createTextAttributesKey("LD65_IDENTIFIER", DefaultLanguageHighlighterColors.IDENTIFIER);
+
+    private static final TextAttributesKey[] COMMENT_KEYS = {COMMENT};
+    private static final TextAttributesKey[] KEYWORD_KEYS = {KEYWORD};
+    private static final TextAttributesKey[] NUMBER_KEYS = {NUMBER};
+    private static final TextAttributesKey[] STRING_KEYS = {STRING};
+    private static final TextAttributesKey[] FORMAT_SPEC_KEYS = {FORMAT_SPEC};
+    private static final TextAttributesKey[] IDENTIFIER_KEYS = {IDENTIFIER};
+    private static final TextAttributesKey[] EMPTY_KEYS = {};
+
+    @Override
+    public @NotNull Lexer getHighlightingLexer() {
+        return new Ld65LexerAdapter();
+    }
+
+    @Override
+    public TextAttributesKey @NotNull [] getTokenHighlights(IElementType tokenType) {
+        if (tokenType == Ld65Types.COMMENT) return COMMENT_KEYS;
+        if (tokenType == Ld65Types.INT_LITERAL) return NUMBER_KEYS;
+        if (tokenType == Ld65Types.STRING_LITERAL) return STRING_KEYS;
+        if (tokenType == Ld65Types.FORMAT_SPEC) return FORMAT_SPEC_KEYS;
+        if (tokenType == Ld65Types.IDENTIFIER) return IDENTIFIER_KEYS;
+        if (tokenType == Ld65Types.MEMORY_KW
+                || tokenType == Ld65Types.SEGMENTS_KW
+                || tokenType == Ld65Types.FILES_KW
+                || tokenType == Ld65Types.FORMATS_KW
+                || tokenType == Ld65Types.FEATURES_KW
+                || tokenType == Ld65Types.SYMBOLS_KW) return KEYWORD_KEYS;
+        return EMPTY_KEYS;
+    }
+}

--- a/src/main/java/org/ca65/ld65/Ld65SyntaxHighlighterFactory.java
+++ b/src/main/java/org/ca65/ld65/Ld65SyntaxHighlighterFactory.java
@@ -1,0 +1,15 @@
+package org.ca65.ld65;
+
+import com.intellij.openapi.fileTypes.SyntaxHighlighter;
+import com.intellij.openapi.fileTypes.SyntaxHighlighterFactory;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class Ld65SyntaxHighlighterFactory extends SyntaxHighlighterFactory {
+    @Override
+    public @NotNull SyntaxHighlighter getSyntaxHighlighter(@Nullable Project project, @Nullable VirtualFile virtualFile) {
+        return new Ld65SyntaxHighlighter();
+    }
+}

--- a/src/main/java/org/ca65/ld65/psi/Ld65ElementType.java
+++ b/src/main/java/org/ca65/ld65/psi/Ld65ElementType.java
@@ -1,0 +1,12 @@
+package org.ca65.ld65.psi;
+
+import com.intellij.psi.tree.IElementType;
+import org.ca65.ld65.Ld65Language;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+
+public class Ld65ElementType extends IElementType {
+    public Ld65ElementType(@NotNull @NonNls String debugName) {
+        super(debugName, Ld65Language.INSTANCE);
+    }
+}

--- a/src/main/java/org/ca65/ld65/psi/Ld65File.java
+++ b/src/main/java/org/ca65/ld65/psi/Ld65File.java
@@ -1,0 +1,24 @@
+package org.ca65.ld65.psi;
+
+import com.intellij.extapi.psi.PsiFileBase;
+import com.intellij.openapi.fileTypes.FileType;
+import com.intellij.psi.FileViewProvider;
+import org.ca65.ld65.Ld65FileType;
+import org.ca65.ld65.Ld65Language;
+import org.jetbrains.annotations.NotNull;
+
+public class Ld65File extends PsiFileBase {
+    public Ld65File(@NotNull FileViewProvider viewProvider) {
+        super(viewProvider, Ld65Language.INSTANCE);
+    }
+
+    @Override
+    public @NotNull FileType getFileType() {
+        return Ld65FileType.INSTANCE;
+    }
+
+    @Override
+    public String toString() {
+        return "ld65 configuration file";
+    }
+}

--- a/src/main/java/org/ca65/ld65/psi/Ld65TokenType.java
+++ b/src/main/java/org/ca65/ld65/psi/Ld65TokenType.java
@@ -1,0 +1,17 @@
+package org.ca65.ld65.psi;
+
+import com.intellij.psi.tree.IElementType;
+import org.ca65.ld65.Ld65Language;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+
+public class Ld65TokenType extends IElementType {
+    public Ld65TokenType(@NotNull @NonNls String debugName) {
+        super(debugName, Ld65Language.INSTANCE);
+    }
+
+    @Override
+    public String toString() {
+        return "Ld65TokenType." + super.toString();
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -17,6 +17,12 @@
   <extensions defaultExtensionNs="com.intellij">
     <fileType name="6502 Assembly" implementationClass="org.ca65.AsmFileType" fieldName="INSTANCE"
               language="6502 Assembly" extensions="s;asm;inc;mac"/>
+    <fileType name="ld65 Config" implementationClass="org.ca65.ld65.Ld65FileType" fieldName="INSTANCE"
+              language="ld65 Config" extensions="cfg"/>
+    <lang.parserDefinition language="ld65 Config"
+                           implementationClass="org.ca65.ld65.Ld65ParserDefinition"/>
+    <lang.syntaxHighlighterFactory language="ld65 Config"
+                                   implementationClass="org.ca65.ld65.Ld65SyntaxHighlighterFactory"/>
     <lang.parserDefinition language="6502 Assembly"
                            implementationClass="org.ca65.AsmParserDefinition"/>
     <lang.syntaxHighlighterFactory language="6502 Assembly"


### PR DESCRIPTION
All ca65 projects define some things in a linker config, either one in the project or one that is bundled with the toolchain.

This is a first cut based on trying to understand the ld65 parser. It can parse all of the `.cfg` files which [ship with cc66](https://github.com/cc65/cc65/tree/master/cfg), but doesn't do anything useful with them yet.

<img width="2230" height="922" alt="image" src="https://github.com/user-attachments/assets/277afbd7-3eb5-4485-a139-130e63877350" />

Marked as draft because the code is all isolated to a subfolder.

This project only handles files in isolation at the moment. A good threshold to merge would be that segment usage in a `.s` file can be followed through to the `.cfg` file or similar.
