### PR TITLE
Unnamed label re-visit

### DIFF
--- a/src/main/java/org/ca65/Asm.flex
+++ b/src/main/java/org/ca65/Asm.flex
@@ -82,7 +82,7 @@ REGISTER_DOT_KEYWORD = "\." ( A16 | A8 | I16 | I8 )
 
 IMPORT_KEYWORD = "\." (IMPORT  | IMPORTZP)
 
-SHORTLABEL_REF = \: (\+ | \-)+
+SHORTLABEL_REF = \: (\+ | \- | \< | \>)+  // angle brackets are an accepted alias for +/-; leading ':' avoids overlap with << / >>
 LOCAL_LABEL_REF = "@" [A-Za-z_]+[A-Za-z0-9_]*
 
 %%

--- a/src/main/java/org/ca65/AsmLineMarkerProvider.java
+++ b/src/main/java/org/ca65/AsmLineMarkerProvider.java
@@ -73,13 +73,16 @@ public class AsmLineMarkerProvider extends RelatedItemLineMarkerProvider {
         }
         String labelText = leafElement.getText().substring(1);
         int len = labelText.length();
+        // '>' is an accepted alias for '+' (forward), '<' for '-' (backward).
+        boolean allForward = labelText.chars().allMatch(c -> c == '+' || c == '>');
+        boolean allBackward = labelText.chars().allMatch(c -> c == '-' || c == '<');
         final PsiElement labelDefinition;
-        if(labelText.equals("+".repeat(len))) {
+        if(allForward) {
             labelDefinition = walkToLabel(maybeJumpInstruction.getParent(), len, true);
-        } else if (labelText.equals("-".repeat(len))) {
+        } else if (allBackward) {
             labelDefinition = walkToLabel(maybeJumpInstruction.getParent(), len, false);
         } else {
-            labelDefinition = null; // reference should be eg. :-- or :++
+            labelDefinition = null; // mixed direction, eg. :+- is not a valid reference
         }
         if(labelDefinition == null) {
             return; // Could not find

--- a/src/main/java/org/ca65/action/NormalizeShortLabelRefIntentionAction.java
+++ b/src/main/java/org/ca65/action/NormalizeShortLabelRefIntentionAction.java
@@ -1,0 +1,56 @@
+package org.ca65.action;
+
+import com.intellij.codeInsight.TargetElementUtilBase;
+import com.intellij.codeInsight.intention.impl.BaseIntentionAction;
+import com.intellij.codeInspection.util.IntentionFamilyName;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.impl.source.tree.LeafPsiElement;
+import com.intellij.util.IncorrectOperationException;
+import org.ca65.Asm6502Bundle;
+import org.ca65.psi.AsmFile;
+import org.ca65.psi.AsmTypes;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Replaces the angle-bracket form of an unnamed label reference (:&gt;, :&lt;)
+ * with the more common :+ / :- form. Cursor-based so the platform can generate a live preview.
+ */
+public class NormalizeShortLabelRefIntentionAction extends BaseIntentionAction {
+    @Override
+    public @NotNull @IntentionFamilyName String getFamilyName() {
+        return Asm6502Bundle.message("INTN.NAME.normalize.shortlabel");
+    }
+
+    @Override
+    public boolean isAvailable(@NotNull Project project, Editor editor, PsiFile file) {
+        if (!(file instanceof AsmFile)) return false;
+        PsiElement ref = getShortLabelRef(editor, file);
+        if (ref == null) return false;
+        String text = ref.getText();
+        if (text.indexOf('<') < 0 && text.indexOf('>') < 0) return false;
+        setText(Asm6502Bundle.message("INTN.normalize.shortlabel", normalize(text)));
+        return true;
+    }
+
+    @Override
+    public void invoke(@NotNull Project project, Editor editor, PsiFile file) throws IncorrectOperationException {
+        PsiElement ref = getShortLabelRef(editor, file);
+        if (!(ref instanceof LeafPsiElement leaf)) return;
+        // replaceWithText swaps the leaf in place (token type is unchanged); no document reparse.
+        leaf.replaceWithText(normalize(leaf.getText()));
+    }
+
+    private static @Nullable PsiElement getShortLabelRef(Editor editor, PsiFile file) {
+        int offset = TargetElementUtilBase.adjustOffset(file, editor.getDocument(), editor.getCaretModel().getOffset());
+        PsiElement element = file.findElementAt(offset);
+        return element != null && element.getNode().getElementType() == AsmTypes.SHORTLABEL_REF ? element : null;
+    }
+
+    private static String normalize(String text) {
+        return text.replace('>', '+').replace('<', '-');
+    }
+}

--- a/src/main/java/org/ca65/action/NormalizeShortLabelRefIntentionAction.java
+++ b/src/main/java/org/ca65/action/NormalizeShortLabelRefIntentionAction.java
@@ -16,7 +16,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Replaces the angle-bracket form of an unnamed label reference (:&gt;, :&lt;)
+ * Replaces the angle-bracket form of an unnamed label reference (:>, :<)
  * with the more common :+ / :- form. Cursor-based so the platform can generate a live preview.
  */
 public class NormalizeShortLabelRefIntentionAction extends BaseIntentionAction {

--- a/src/main/java/org/ca65/annotator/AsmShortLabelRefAnnotator.java
+++ b/src/main/java/org/ca65/annotator/AsmShortLabelRefAnnotator.java
@@ -12,7 +12,7 @@ import org.ca65.psi.AsmTypes;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Flags unnamed label references that use angle brackets (:&gt;, :&lt;) and offers
+ * Flags unnamed label references that use angle brackets (:>, :<) and offers
  * to normalise them to the more common :+ / :- form.
  */
 public class AsmShortLabelRefAnnotator implements Annotator {

--- a/src/main/java/org/ca65/annotator/AsmShortLabelRefAnnotator.java
+++ b/src/main/java/org/ca65/annotator/AsmShortLabelRefAnnotator.java
@@ -1,0 +1,32 @@
+package org.ca65.annotator;
+
+import com.intellij.codeInspection.ProblemHighlightType;
+import com.intellij.lang.annotation.AnnotationHolder;
+import com.intellij.lang.annotation.Annotator;
+import com.intellij.lang.annotation.HighlightSeverity;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.impl.source.tree.LeafPsiElement;
+import org.ca65.Asm6502Bundle;
+import org.ca65.action.NormalizeShortLabelRefIntentionAction;
+import org.ca65.psi.AsmTypes;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Flags unnamed label references that use angle brackets (:&gt;, :&lt;) and offers
+ * to normalise them to the more common :+ / :- form.
+ */
+public class AsmShortLabelRefAnnotator implements Annotator {
+    @Override
+    public void annotate(@NotNull PsiElement element, @NotNull AnnotationHolder holder) {
+        if (!(element instanceof LeafPsiElement leaf)) return;
+        if (leaf.getElementType() != AsmTypes.SHORTLABEL_REF) return;
+        String text = leaf.getText();
+        if (text.indexOf('<') < 0 && text.indexOf('>') < 0) return;
+        holder.newAnnotation(HighlightSeverity.WEAK_WARNING,
+                        Asm6502Bundle.message("INSPECT.shortlabel.angle", text))
+                .range(leaf.getTextRange())
+                .highlightType(ProblemHighlightType.WEAK_WARNING)
+                .withFix(new NormalizeShortLabelRefIntentionAction())
+                .create();
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -43,6 +43,7 @@
     <annotator language="6502 Assembly" implementationClass="org.ca65.annotator.AsmNumericLiteralAnnotator"/>
     <annotator language="6502 Assembly" implementationClass="org.ca65.annotator.AsmStarAssignAnnotator"/>
     <annotator language="6502 Assembly" implementationClass="org.ca65.annotator.AsmZilogHexAnnotator"/>
+    <annotator language="6502 Assembly" implementationClass="org.ca65.annotator.AsmShortLabelRefAnnotator"/>
     <projectService serviceImplementation="org.ca65.config.AsmConfiguration" />
     <lang.documentationProvider language="6502 Assembly" implementationClass="org.ca65.AsmDocumentationProvider"/>
 

--- a/src/main/resources/messages/Asm6502Bundle.properties
+++ b/src/main/resources/messages/Asm6502Bundle.properties
@@ -29,3 +29,7 @@ INSPECT.zilog.hex=Zilog/Intel-style hex literal ''{0}'' is non-idiomatic; use ca
 INSPECT.underscores.in.literal=Literal ''{0}'' uses underscores, which depends on the non-default ''.feature underline_in_numbers'' assembler flag.
 INTN.NAME.remove.underscores=Remove underscores from numeric literal
 INTN.remove.underscores=Replace with ''{0}''
+
+INSPECT.shortlabel.angle=Unnamed label reference ''{0}'' uses angle brackets; the ''+''/''-'' form is more common
+INTN.NAME.normalize.shortlabel=Normalize unnamed label reference
+INTN.normalize.shortlabel=Replace with ''{0}''


### PR DESCRIPTION
This change updates handling for unnamed labels, which is the very terse syntax where you just reference how many labels to jump forward/backward.

```
:
  inx
  cpx #50
  bne :-
```

I found out that in addition to `:+`/`:++`/`:-`/`:--`, you can also use syntax like  `:>`/`:>>`/`:<`/`:<<`. This previously lexed incorrectly because it looks like stray comparison/shift operators.

These will now be accepted (and the references resolved), but this plugin tries to direct you to an idiomatic syntax, so you also get a weak warning and quick-fix suggestion.

<img width="1005" height="168" alt="Screenshot From 2026-06-29 17-05-57" src="https://github.com/user-attachments/assets/3fd1ceba-906e-4abd-8bff-d3f030edf62b" />

Possible future work in this area:

- A refactoring which allows assigning a name to these unnamed labels
- Confirming what happens if you mix label types. I'm aware of inconsistencies in the plugin if you eg. use  `:+` but the next label has a name, you can navigate to it, but that label will show as 'unused' if that is the only incoming reference.
