### PR TITLE
Fix for deprecated inlay hint function usage

### DIFF
--- a/src/main/java/org/ca65/AsmEnumValueInlayHintProvider.java
+++ b/src/main/java/org/ca65/AsmEnumValueInlayHintProvider.java
@@ -30,7 +30,7 @@ public class AsmEnumValueInlayHintProvider implements InlayHintsProvider {
                         new InlineInlayPosition(offset, false, 0),
                         null,
                         hint,
-                        false,
+                        HintFormat.Companion.getDefault().withColorKind(HintColorKind.TextWithoutBackground),
                         builder -> {
                             builder.text(hint, null);
                             return Unit.INSTANCE;


### PR DESCRIPTION
Switching method signature to avoid this:

```
Deprecated method com.intellij.codeInsight.hints.declarative.InlayTreeSink.addPresentation(com.intellij.codeInsight.hints.declarative.InlayPosition position, java.util.List payloads, java.lang.String tooltip, boolean hasBackground, kotlin.jvm.functions.Function1 builder) : void is invoked in org.ca65.AsmEnumValueInlayHintProvider$1.collectFromElement(PsiElement, InlayTreeSink) : void
```
